### PR TITLE
Add Google analytics to site

### DIFF
--- a/lib/gtag.ts
+++ b/lib/gtag.ts
@@ -1,0 +1,15 @@
+type GTagEvent = {
+  action: string;
+  category: string;
+  label: string;
+  value?: number;
+};
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }: GTagEvent): void => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,9 @@
         "sass": "^1.67.0",
         "tailwindcss": "3.3.3",
         "typescript": "5.2.2"
+      },
+      "devDependencies": {
+        "@types/gtag.js": "^0.0.13"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -626,6 +629,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/@types/gtag.js": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.13.tgz",
+      "integrity": "sha512-yOXFkfnt1DQr1v9B4ERulJOGnbdVqnPHV8NG4nkQhnu4qbrJecQ06DlaKmSjI3nzIwBj5U9/X61LY4sTc2KbaQ==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -4825,6 +4834,12 @@
           }
         }
       }
+    },
+    "@types/gtag.js": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.13.tgz",
+      "integrity": "sha512-yOXFkfnt1DQr1v9B4ERulJOGnbdVqnPHV8NG4nkQhnu4qbrJecQ06DlaKmSjI3nzIwBj5U9/X61LY4sTc2KbaQ==",
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "sass": "^1.67.0",
     "tailwindcss": "3.3.3",
     "typescript": "5.2.2"
+  },
+  "devDependencies": {
+    "@types/gtag.js": "^0.0.13"
   }
 }

--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -1,6 +1,7 @@
 import '../globals.scss'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import Script from 'next/script';
 import { Header } from '../components/header'
 import { Footer } from '../components/footer'
 
@@ -39,6 +40,15 @@ export default async function RootLayout({
 
   return (
     <html lang={lng} dir={dir(lng)}>
+      <Script strategy="afterInteractive" src="https://www.googletagmanager.com/gtag/js?id=G-6P1MW6NND8"/>
+      <Script strategy="afterInteractive" id="google-analytics">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-6P1MW6NND8');
+        `}
+      </Script>
       <body className={inter.className}>
         <Header navigation={navigationItems} />
         {children}


### PR DESCRIPTION
PR adds gtag to the site, a lot of events are emitted by default but I also added an `event` function to `/lib/gtag.ts` that you can use to emit any other events stakeholders may want.

Not sure if layout.ts is the best place for the instantiation of GA, but feel free to move it where it makes the most sense.

Used this resource for set up FYI: https://nextjs.org/docs/messages/next-script-for-ga 