### PR TITLE
Add GA events to link and nav clicks

### DIFF
--- a/lib/gtag.ts
+++ b/lib/gtag.ts
@@ -1,7 +1,7 @@
 type GTagEvent = {
   action: string;
   category: string;
-  label: string;
+  label?: string;
   value?: number;
 };
 

--- a/src/app/components/events-list/events-list.tsx
+++ b/src/app/components/events-list/events-list.tsx
@@ -14,6 +14,7 @@ import {
     MenuLink,
 } from "@reach/menu-button";
 
+import * as gtag from "../../../../lib/gtag";
 import "@reach/tabs/styles.css";
 import "@reach/menu-button/styles.css";
 
@@ -139,6 +140,13 @@ export const EventsList = () => {
         setTabIndex(index);
     };
 
+    const handleTalkClick = (talk: Talk) => {
+        gtag.event({
+            action: talk.name,
+            category: "Ticket link click"
+        })
+    }
+
     if (!events || events.length === 0) {
         return null;
     }
@@ -188,7 +196,7 @@ export const EventsList = () => {
                                                 <h3 className={`event-talk-name`}>{talk.name}</h3>
                                                 <p>{talk.content}</p>
                                                 {talk.url && (
-                                                    <Link className={`btn btn-primary`} href={talk.url} target="_blank" rel="noreferrer noopener">Get the tickets</Link>
+                                                    <Link className={`btn btn-primary`} onClick={() => handleTalkClick(talk)} href={talk.url} target="_blank" rel="noreferrer noopener">Get the tickets</Link>
                                                 )}
                                                 {talk.inviteOnly && (
                                                     <p className={`event-talk-invite-only`}>[Invite Only]</p>

--- a/src/app/components/header/header.tsx
+++ b/src/app/components/header/header.tsx
@@ -5,8 +5,17 @@ import { Popover } from '@headlessui/react'
 import Link from 'next/link';
 import Image from "next/image";
 import { HeaderProps } from "./types";
+import * as gtag from "../../../../lib/gtag";
 
 export const Header: React.FC<HeaderProps> = ({ navigation }) => {
+
+    const handleLinkClick = (linkName: string) => {
+        gtag.event({
+            action: linkName,
+            category: "Header Navigation Click"
+        })
+    }
+
     return (
         <div className="sticky top-0 z-50 w-full ">
 
@@ -14,7 +23,7 @@ export const Header: React.FC<HeaderProps> = ({ navigation }) => {
                 <div className="px-4 sm:px-6 container container--xl">
                     <div className="flex items-center justify-between py-6 md:justify-start md:space-x-10">
                         <div className="flex justify-start lg:w-0 lg:flex-1">
-                            <Link href="/">
+                            <Link href="/" onClick={() => handleLinkClick('home')}>
                                 <span className="sr-only">Reimagine</span>
                                 <Image
                                     height={70}
@@ -28,7 +37,7 @@ export const Header: React.FC<HeaderProps> = ({ navigation }) => {
                         <Popover.Group as="nav" className="space-x-10 md:flex">
                             {
                                 navigation.map((item, index) => (
-                                    <Link key={index} href={`#${item.slug}`} className="text-base font-bold text-gray-900 hover:underline">
+                                    <Link key={index} href={`#${item.slug}`} onClick={() => handleLinkClick(item.text)} className="text-base font-bold text-gray-900 hover:underline">
                                         {item.text}
                                     </Link>
                                 ))

--- a/src/app/components/language-selector/language-selector.js
+++ b/src/app/components/language-selector/language-selector.js
@@ -3,6 +3,7 @@ import { useSelect } from "downshift";
 import classNames from "classnames";
 import Link from "next/link";
 import styles from "./language-selector.module.css";
+import * as gtag from "/lib/gtag.ts";
 
 export const LanguageSelector = () => {
   const locale = "en";
@@ -21,6 +22,13 @@ export const LanguageSelector = () => {
     highlightedIndex,
     getItemProps,
   } = useSelect({ items });
+
+  const handleLanguageChange = (locale) => {
+    gtag.event({
+      action: `Locale change: ${locale}`,
+      category: "Link click"
+    })
+  }
 
   return (
     <div className={styles.wrapper}>
@@ -50,7 +58,7 @@ export const LanguageSelector = () => {
               {...getItemProps({ item, index })}
               className={styles.item}
             >
-              <Link href={pathname} locale={item} className={styles.link}>
+              <Link href={pathname} locale={item} className={styles.link} onClick={(item) => handleLanguageChange(item)}>
                 {`${languageNames.of(item)} - ${item.toUpperCase()}`}
               </Link>
             </li>


### PR DESCRIPTION
PR adds GA events to several places:
- Navigation clicks
- Click on any of the "Get Ticket" links
- Language switcher clicks