### PR TITLE
Change header links to `<a>` element

### DIFF
--- a/src/app/components/header/header.tsx
+++ b/src/app/components/header/header.tsx
@@ -5,8 +5,17 @@ import { Popover } from '@headlessui/react'
 import Link from 'next/link';
 import Image from "next/image";
 import { HeaderProps } from "./types";
+import * as gtag from "../../../../lib/gtag";
 
 export const Header: React.FC<HeaderProps> = ({ navigation }) => {
+
+    const handleLinkClick = (location: string) => {
+        gtag.event({
+            action: `Link to: ${location}`,
+            category: "Nav item click"
+        })
+    }
+
 
     return (
         <div className="sticky top-0 z-50 w-full ">
@@ -15,7 +24,7 @@ export const Header: React.FC<HeaderProps> = ({ navigation }) => {
                 <div className="px-4 sm:px-6 container container--xl">
                     <div className="flex items-center justify-between py-6 md:justify-start md:space-x-10">
                         <div className="flex justify-start lg:w-0 lg:flex-1">
-                            <Link href="/">
+                            <a href="/" onClick={() => handleLinkClick('home')}>
                                 <span className="sr-only">Reimagine</span>
                                 <Image
                                     height={70}
@@ -24,14 +33,14 @@ export const Header: React.FC<HeaderProps> = ({ navigation }) => {
                                     src="/mozilla-logo-wordmark.svg"
                                     alt="Mozilla Foundation"
                                 />
-                            </Link>
+                            </a>
                         </div>
                         <Popover.Group as="nav" className="space-x-10 md:flex">
                             {
                                 navigation.map((item, index) => (
-                                    <Link key={index} href={`#${item.slug}`} className="text-base font-bold text-gray-900 hover:underline">
+                                    <a key={index} href={`#${item.slug}`} onClick={() => handleLinkClick(item.text)} className="text-base font-bold text-gray-900 hover:underline">
                                         {item.text}
-                                    </Link>
+                                    </a>
                                 ))
                             }
                         </Popover.Group>


### PR DESCRIPTION
Attempting to fix the issues with the links in the Header component - changed all `<Link>` elements to HTML anchor elements in the Header. This should allow us to still use GA event emitters 